### PR TITLE
ci: add github actions and codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+
+# These owners will be the default owners for everything in the
+# repo. Unless a later match takes precedence, owners listed here
+# will be requested for review when someone opens a pull request.
+*       @edaniszewski
+
+# Order is important; the last matching pattern takes the most
+# precedence. Additional matches may be added below (e.g. *.py
+# for pull requests that only modify Python files).

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,20 @@
+on:
+  push: {}
+  pull_request: {}
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    name: Python 3.8 Lint
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+    - name: Install dependencies
+      run: |
+        python -m pip install -U pip setuptools wheel
+        python -m pip install -U tox tox-gh-actions
+    - name: Lint
+      run: tox -e lint

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,25 @@
+name: test
+on:
+  push: {}
+  pull_request: {}
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        py-version: ['3.6', '3.7', '3.8']
+    name: Python ${{ matrix.py-version }} Test
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.py-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install -U pip setuptools wheel
+        python -m pip install -U tox tox-gh-actions
+    - name: Run tests
+      run: tox

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,15 @@ test:  ## Run the project unit tests
 version:  ## Print the package version
 	@echo "${PKG_VERSION}"
 
-.PHONY: unit-test
-unit-test: test
-
 help:  ## Print usage information
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z0-9_-]+:.*?## / {printf "\033[36m%-16s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
+
+
+# Jenkins CI Pipeline Targets
+.PHONY: unit-test pypi-release
+
+unit-test:
+	tox -e py38
+
+pypi-release:
+	tox -e release

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,31 @@
 [tox]
-envlist=py3
+envlist = py{36,37,38}
+skip_missing_interpreters = True
+
+[gh-actions]
+python =
+    3.6: py36
+    3.7: py37
+    3.8: py38,lint
 
 [testenv]
+basepython =
+    py36: python3.6
+    py37: python3.7
+    py38: python3.8
 deps =
     pytest
     pytest-cov
 commands =
     pip install -e .
-    pytest -s \
+    pytest -s -vv \
         --cov-report html \
         --cov-report term \
         --cov containerlog \
         {posargs}
 
-
 [testenv:fmt]
+basepython = python3
 deps =
     isort>=5.0.0
     autopep8
@@ -22,8 +33,8 @@ commands =
     isort --atomic {posargs:containerlog tests benchmarks}
     autopep8 --recursive --in-place {toxinidir}
 
-
 [testenv:lint]
+basepython = python3
 deps =
     isort>=5.0.0
     flake8
@@ -34,8 +45,8 @@ commands =
     python setup.py sdist bdist_wheel
     twine check dist/*
 
-
 [testenv:release]
+basepython = python3
 deps =
     twine>=1.12.0
 passenv =


### PR DESCRIPTION
This PR:
- adds GH actions as a basic public facing CI to run in parallel with the internal jenkins pipeline
- adds a CODEOWNERS file with myself as an owner so I get automatically requested on PR reviews
- updates tox config/make targets

fixes #9 