### PR TITLE
distribute type info with package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,11 @@ setup(
     author=pkg['__author__'],
     author_email=pkg['__author_email__'],
     packages=find_packages(),
-    package_data={'': ['LICENSE']},
+    package_data={
+        '': ['LICENSE'],
+        'containerlog': ['py.typed'],
+    },
+    include_package_data=True,
     python_requires='>=3.6',
     install_requires=[],
     classifiers=[
@@ -43,5 +47,4 @@ setup(
         'Operating System :: OS Independent',
     ],
     zip_safe=False,
-    include_package_data=True,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -27,10 +27,12 @@ commands =
 deps =
     isort>=5.0.0
     flake8
+    mypy
     twine>=1.12.0
 commands =
     isort --check --diff {posargs:containerlog tests benchmarks}
     flake8 --show-source --statistics {posargs:containerlog tests benchmarks}
+    mypy containerlog
     python setup.py sdist bdist_wheel
     twine check dist/*
 


### PR DESCRIPTION
This PR:
- adds a py.typed file and corresponding packaging updates  to distribute type info with the package per [PEP 561](https://www.python.org/dev/peps/pep-0561/)
- adds mypy type checking to linting stage
- updates/fixes based on type linting issues