### PR TITLE
feat: define __slots__ for logger classes

### DIFF
--- a/containerlog/__init__.py
+++ b/containerlog/__init__.py
@@ -48,6 +48,15 @@ class Logger:
             level may be set for all loggers globally via `set_level`.
     """
 
+    __slots__ = (
+        'name',
+        'level',
+        'utcnow',
+        'writeout',
+        'writeerr',
+        '_previous_level',
+    )
+
     _level_lookup = {
         0: 'trace',
         1: 'debug',
@@ -228,6 +237,11 @@ class Manager:
     Args:
         level: The global log level to apply to all Loggers on initialization.
     """
+
+    __slots__ = (
+        'level',
+        'loggers',
+    )
 
     def __init__(self, level: int = DEBUG) -> None:
         self.level: int = level

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ def reset_manager():
 
 
 @pytest.fixture()
-def logger():
+def test_logger():
     """Fixture to get an instance of a Logger with mocked proxy module functions."""
     err = io.StringIO()
     out = io.StringIO()
@@ -25,10 +25,8 @@ def logger():
     log.utcnow = lambda: datetime.datetime(2020, 1, 1)
     log.writeout = out.write
     log.writeerr = err.write
-    log.err = err
-    log.out = out
 
-    yield log
+    yield log, out, err
 
     err.close()
     out.close()

--- a/tests/test_containerlog.py
+++ b/tests/test_containerlog.py
@@ -235,109 +235,122 @@ class TestLogger:
             ),
         ],
     )
-    def test_log(self, loglevel, msg, kwargs, out, err, logger):
+    def test_log(self, loglevel, msg, kwargs, out, err, test_logger):
+        logger, o, e = test_logger
+
         logger.level = loglevel
         logger._log(loglevel, msg, **kwargs)
 
-        # .out and .err monkey-patched in at fixture
-        assert logger.out.getvalue() == out
-        assert logger.err.getvalue() == err
+        assert o.getvalue() == out
+        assert e.getvalue() == err
 
-    def test_trace(self, logger):
+    def test_trace(self, test_logger):
+        logger, o, e = test_logger
+
         logger.level = containerlog.TRACE
         logger.trace('test message', key='value')
 
-        # .out and .err monkey-patched in at fixture
-        assert logger.out.getvalue() == "timestamp='2020-01-01T00:00:00Z' logger='test' level='trace' event='test message' key='value'\n"  # noqa
-        assert logger.err.getvalue() == ''
+        assert o.getvalue() == "timestamp='2020-01-01T00:00:00Z' logger='test' level='trace' event='test message' key='value'\n"  # noqa
+        assert e.getvalue() == ''
 
-    def test_trace_nolog(self, logger):
+    def test_trace_nolog(self, test_logger):
+        logger, o, e = test_logger
+
         logger.level = 99
         logger.trace('test message', key='value')
 
-        # .out and .err monkey-patched in at fixture
-        assert logger.out.getvalue() == ''
-        assert logger.err.getvalue() == ''
+        assert o.getvalue() == ''
+        assert e.getvalue() == ''
 
-    def test_debug(self, logger):
+    def test_debug(self, test_logger):
+        logger, o, e = test_logger
+
         logger.level = containerlog.DEBUG
         logger.debug('test message', key='value')
 
-        # .out and .err monkey-patched in at fixture
-        assert logger.out.getvalue() == "timestamp='2020-01-01T00:00:00Z' logger='test' level='debug' event='test message' key='value'\n"  # noqa
-        assert logger.err.getvalue() == ''
+        assert o.getvalue() == "timestamp='2020-01-01T00:00:00Z' logger='test' level='debug' event='test message' key='value'\n"  # noqa
+        assert e.getvalue() == ''
 
-    def test_debug_nolog(self, logger):
+    def test_debug_nolog(self, test_logger):
+        logger, o, e = test_logger
+
         logger.level = 99
         logger.debug('test message', key='value')
 
-        # .out and .err monkey-patched in at fixture
-        assert logger.out.getvalue() == ''
-        assert logger.err.getvalue() == ''
+        assert o.getvalue() == ''
+        assert e.getvalue() == ''
 
-    def test_info(self, logger):
+    def test_info(self, test_logger):
+        logger, o, e = test_logger
+
         logger.level = containerlog.INFO
         logger.info('test message', key='value')
 
-        # .out and .err monkey-patched in at fixture
-        assert logger.out.getvalue() == "timestamp='2020-01-01T00:00:00Z' logger='test' level='info' event='test message' key='value'\n"  # noqa
-        assert logger.err.getvalue() == ''
+        assert o.getvalue() == "timestamp='2020-01-01T00:00:00Z' logger='test' level='info' event='test message' key='value'\n"  # noqa
+        assert e.getvalue() == ''
 
-    def test_info_nolog(self, logger):
+    def test_info_nolog(self, test_logger):
+        logger, o, e = test_logger
+
         logger.level = 99
         logger.info('test message', key='value')
 
-        # .out and .err monkey-patched in at fixture
-        assert logger.out.getvalue() == ''
-        assert logger.err.getvalue() == ''
+        assert o.getvalue() == ''
+        assert e.getvalue() == ''
 
-    def test_warn(self, logger):
+    def test_warn(self, test_logger):
+        logger, o, e = test_logger
+
         logger.level = containerlog.WARN
         logger.warn('test message', key='value')
 
-        # .out and .err monkey-patched in at fixture
-        assert logger.out.getvalue() == "timestamp='2020-01-01T00:00:00Z' logger='test' level='warn' event='test message' key='value'\n"  # noqa
-        assert logger.err.getvalue() == ''
+        assert o.getvalue() == "timestamp='2020-01-01T00:00:00Z' logger='test' level='warn' event='test message' key='value'\n"  # noqa
+        assert e.getvalue() == ''
 
-    def test_warn_nolog(self, logger):
+    def test_warn_nolog(self, test_logger):
+        logger, o, e = test_logger
+
         logger.level = 99
         logger.warn('test message', key='value')
 
-        # .out and .err monkey-patched in at fixture
-        assert logger.out.getvalue() == ''
-        assert logger.err.getvalue() == ''
+        assert o.getvalue() == ''
+        assert e.getvalue() == ''
 
-    def test_error(self, logger):
+    def test_error(self, test_logger):
+        logger, o, e = test_logger
+
         logger.level = containerlog.ERROR
         logger.error('test message', key='value')
 
-        # .out and .err monkey-patched in at fixture
-        assert logger.out.getvalue() == ''
-        assert logger.err.getvalue() == "timestamp='2020-01-01T00:00:00Z' logger='test' level='error' event='test message' key='value'\n"  # noqa
+        assert o.getvalue() == ''
+        assert e.getvalue() == "timestamp='2020-01-01T00:00:00Z' logger='test' level='error' event='test message' key='value'\n"  # noqa
 
-    def test_error_nolog(self, logger):
+    def test_error_nolog(self, test_logger):
+        logger, o, e = test_logger
+
         logger.level = 99
         logger.error('test message', key='value')
 
-        # .out and .err monkey-patched in at fixture
-        assert logger.out.getvalue() == ''
-        assert logger.err.getvalue() == ''
+        assert o.getvalue() == ''
+        assert e.getvalue() == ''
 
-    def test_critical(self, logger):
+    def test_critical(self, test_logger):
+        logger, o, e = test_logger
+
         logger.level = containerlog.CRITICAL
         logger.critical('test message', key='value')
 
-        # .out and .err monkey-patched in at fixture
-        assert logger.out.getvalue() == ''
-        assert logger.err.getvalue() == "timestamp='2020-01-01T00:00:00Z' logger='test' level='critical' event='test message' key='value'\n"  # noqa
+        assert o.getvalue() == ''
+        assert e.getvalue() == "timestamp='2020-01-01T00:00:00Z' logger='test' level='critical' event='test message' key='value'\n"  # noqa
 
-    def test_critical_nolog(self, logger):
+    def test_critical_nolog(self, test_logger):
+        logger, o, e = test_logger
+
         logger.level = 99
         logger.critical('test message', key='value')
 
-        # .out and .err monkey-patched in at fixture
-        assert logger.out.getvalue() == ''
-        assert logger.err.getvalue() == ''
+        assert o.getvalue() == ''
+        assert e.getvalue() == ''
 
 
 def test_get_logger_existing():


### PR DESCRIPTION
This PR:
- adds `__slots__` to logger classes
- updates tests/fixtures because we can no longer monkey-patch values onto the logger for tests

fixes #17 