### PR TITLE
optim: micro-optimize log level name lookup

### DIFF
--- a/containerlog/__init__.py
+++ b/containerlog/__init__.py
@@ -57,14 +57,14 @@ class Logger:
         '_previous_level',
     )
 
-    _level_lookup = {
-        0: 'trace',
-        1: 'debug',
-        2: 'info',
-        3: 'warn',
-        4: 'error',
-        5: 'critical',
-    }
+    _level_lookup = (
+        'trace',
+        'debug',
+        'info',
+        'warn',
+        'error',
+        'critical',
+    )
 
     def __init__(self, name: str, level: Optional[int] = None) -> None:
         self.name: str = name


### PR DESCRIPTION
When I say micro-optimize, I really mean micro.

From some simple timing tests, this change looks like it shaves off about 1.0e^-8 seconds per call, which is not a lot.

Perhaps a bit more worthwhile is that it also reduces the memory footprint for the collection allocation from 360 bytes (dict implementation) to 88 bytes (tuple implementation), so thats nice, even though small.


fixes #18

