### PR TITLE
fix: make contextvar procecssors accessible to all loggers

### DIFF
--- a/containerlog/__init__.py
+++ b/containerlog/__init__.py
@@ -52,11 +52,11 @@ class Logger:
 
     __slots__ = (
         "name",
+        "manager",
         "level",
         "utcnow",
         "writeout",
         "writeerr",
-        "context_processors",
         "_previous_level",
     )
 
@@ -72,14 +72,13 @@ class Logger:
     def __init__(
         self,
         name: str,
+        manager: "Manager",
         level: Optional[int] = None,
-        processors: Optional[Iterable[ContextProcessor]] = None,
     ) -> None:
         self.name: str = name
         self.level: int = DEBUG if level is None else level
         self._previous_level: Optional[int] = None
-
-        self.context_processors: Iterable[ContextProcessor] = processors or []
+        self.manager: Manager = manager
 
         # Proxy module functions being used into the class scope. This
         # speeds things up by making what would otherwise be a LOAD_GLOBAL
@@ -149,7 +148,7 @@ class Logger:
             del kwargs["event"]
 
         fields: EventContext = {}
-        for processor in self.context_processors:
+        for processor in self.manager.context_processors:
             processor.merge(fields)
 
         fields.update(kwargs)
@@ -340,7 +339,7 @@ def get_logger(name: Optional[str] = None) -> Logger:
         logger = Logger(
             name=name,
             level=manager.level,
-            processors=manager.context_processors,
+            manager=manager,
         )
         manager.loggers[name] = logger
 

--- a/containerlog/contextvars.py
+++ b/containerlog/contextvars.py
@@ -5,6 +5,7 @@ https://docs.python.org/3/library/contextvars.html), introduced in
 Python 3.7.
 """
 
+import contextlib
 import contextvars
 from typing import Any, Dict
 
@@ -63,6 +64,26 @@ def unbind(*keys: str) -> None:
         key = f"{CTXVAR_PREFIX}{k}"
         if key in _CTXVARS:
             _CTXVARS[key].set(Ellipsis)
+
+
+@contextlib.contextmanager
+def context_binding(**kwargs):
+    """A context manager to support binding/unbinding of key-value pairs to
+    the async-aware contextvar state.
+
+    Args:
+        kwargs: The key-value pairs to bind as event context.
+    """
+    bind(**kwargs)
+    try:
+        yield
+    finally:
+        print("•••••••••••••••••••••••")
+        print(f"unbinding: {kwargs.keys()}")
+        print("•••••••••••••••••••••••")
+        unbind(*kwargs.keys())
+
+        print(_CTXVARS)
 
 
 def clear() -> None:

--- a/examples/async_context_binding/main.py
+++ b/examples/async_context_binding/main.py
@@ -5,11 +5,17 @@ import random
 import time
 
 from containerlog import enable_contextvars, get_logger
-from containerlog.contextvars import bind, unbind
+from containerlog.contextvars import bind, context_binding, unbind
 
 enable_contextvars()
 
 logger = get_logger()
+l2 = get_logger("other")
+
+
+async def nested():
+    with context_binding(scope="nested"):
+        l2.info("additional call")
 
 
 async def run(name: str):
@@ -19,6 +25,7 @@ async def run(name: str):
     for _ in range(10):
         wait = random.randrange(1, 15) / 10
         logger.info("waiting for next message", now=time.time(), wait=wait)
+        await nested()
         await asyncio.sleep(wait)
 
     logger.info("unbinding runner name")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ def test_logger():
     """Fixture to get an instance of a Logger with mocked proxy module functions."""
     err = io.StringIO()
     out = io.StringIO()
-    log = containerlog.Logger(name="test")
+    log = containerlog.Logger(name="test", manager=containerlog.manager)
 
     log.utcnow = lambda: datetime.datetime(2020, 1, 1)
     log.writeout = out.write


### PR DESCRIPTION
This PR:
- allows all loggers to acccess processors, so processors may be added later and still be accessible to existing loggers

fixes #81